### PR TITLE
accept data only if it is dict object

### DIFF
--- a/schoolyourself/schoolyourself_review.py
+++ b/schoolyourself/schoolyourself_review.py
@@ -88,6 +88,9 @@ class SchoolYourselfReviewXBlock(SchoolYourselfXBlock):
       that the signature is valid. If everything is good, then we'll
       publish a "grade" event for this module.
       """
+      if not isinstance(data, dict):
+          return "bad request"
+
       mastery = data.get("mastery", None)
       user_id = data.get("user_id", None)
       signature = data.get("signature", None)


### PR DESCRIPTION
[TNL-1395](https://openedx.atlassian.net/browse/TNL-1395)
'unicode' object has no attribute 'get'

If data is not object of dict then its a "bad request"
